### PR TITLE
Add XR Sim Auto Enable

### DIFF
--- a/Assets/Scenes/DemoScene.unity
+++ b/Assets/Scenes/DemoScene.unity
@@ -1651,6 +1651,12 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 485597212}
   m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &645878648 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6598815579406187037, guid: 18ddb545287c546e19cc77dc9fbb2189,
+    type: 3}
+  m_PrefabInstance: {fileID: 1940529443}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &646628510
 GameObject:
   m_ObjectHideFlags: 0
@@ -4589,6 +4595,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1731572768}
+  - component: {fileID: 1731572769}
   m_Layer: 0
   m_Name: -- XR --
   m_TagString: Untagged
@@ -4614,6 +4621,20 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1731572769
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1731572767}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 26895f732e2b84d9ea8a82014e286ad1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _overrideActive: 0
+  _xrSim: {fileID: 645878648}
 --- !u!1 &1793832396
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/XRSimAutoEnable.cs
+++ b/Assets/Scripts/XRSimAutoEnable.cs
@@ -1,0 +1,18 @@
+using UnityEngine;
+
+public class XRSimAutoEnable : MonoBehaviour
+{
+    [SerializeField, Tooltip("In editor, will always deacitave the XR Sim, in build, will always activate the XR Sim")] private bool _overrideActive;
+    [SerializeField] GameObject _xrSim;
+    // Start is called before the first frame update
+    void Start()
+    {
+        // TODO: See if we can pickup the device from editor/build 
+        //       and automatically figure out if need to activate.
+#if UNITY_EDITOR
+        _xrSim.SetActive(!_overrideActive);
+#else
+        _xrSim.SetActive(_overrideActive);
+#endif
+    }
+}

--- a/Assets/Scripts/XRSimAutoEnable.cs
+++ b/Assets/Scripts/XRSimAutoEnable.cs
@@ -9,10 +9,17 @@ public class XRSimAutoEnable : MonoBehaviour
     {
         // TODO: See if we can pickup the device from editor/build 
         //       and automatically figure out if need to activate.
+        if(_xrSim)
+        {
 #if UNITY_EDITOR
         _xrSim.SetActive(!_overrideActive);
 #else
         _xrSim.SetActive(_overrideActive);
 #endif
+        }
+        else 
+        {
+            Debug.LogWarning("No XR Sim assigned!");
+        }
     }
 }

--- a/Assets/Scripts/XRSimAutoEnable.cs.meta
+++ b/Assets/Scripts/XRSimAutoEnable.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 26895f732e2b84d9ea8a82014e286ad1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
The script will automatically activate the XR sim on play in editor. This will help fix issue playing when not on VR device. The component is located at the top `-- XR --` object for most visibility.