### PR TITLE
Added Main Pollution Manager & linked Light system to it

### DIFF
--- a/Assets/Prefab/Fog.prefab
+++ b/Assets/Prefab/Fog.prefab
@@ -30,8 +30,7 @@ Transform:
   m_LocalPosition: {x: -0.47, y: 2.5, z: 9.4}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 2032370950346824821}
+  m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: -90, y: 0, z: 0}
@@ -4830,115 +4829,7 @@ MonoBehaviour:
   _system: {fileID: 3859955815303043260}
   _endTimeThreshold: 1
   _particleCountThreshold: 0
+  _tag: DamageCollider
   OnParticleEnd:
     m_PersistentCalls:
-      m_Calls:
-      - m_Target: {fileID: 2032370950346824818}
-        m_TargetAssemblyTypeName: LightController, Scripts
-        m_MethodName: EndLightEffect
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
---- !u!1001 &8427992991924230077
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 3859955815303043263}
-    m_Modifications:
-    - target: {fileID: 7548684322398456776, guid: 50a6408f36e3a6c40b69e6f13afdcc45,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7548684322398456776, guid: 50a6408f36e3a6c40b69e6f13afdcc45,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7548684322398456776, guid: 50a6408f36e3a6c40b69e6f13afdcc45,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7548684322398456776, guid: 50a6408f36e3a6c40b69e6f13afdcc45,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7548684322398456776, guid: 50a6408f36e3a6c40b69e6f13afdcc45,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7548684322398456776, guid: 50a6408f36e3a6c40b69e6f13afdcc45,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7548684322398456776, guid: 50a6408f36e3a6c40b69e6f13afdcc45,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7548684322398456776, guid: 50a6408f36e3a6c40b69e6f13afdcc45,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7548684322398456776, guid: 50a6408f36e3a6c40b69e6f13afdcc45,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7548684322398456776, guid: 50a6408f36e3a6c40b69e6f13afdcc45,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7548684322398456776, guid: 50a6408f36e3a6c40b69e6f13afdcc45,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7548684322398456777, guid: 50a6408f36e3a6c40b69e6f13afdcc45,
-        type: 3}
-      propertyPath: m_Name
-      value: LightController
-      objectReference: {fileID: 0}
-    - target: {fileID: 7548684322398456783, guid: 50a6408f36e3a6c40b69e6f13afdcc45,
-        type: 3}
-      propertyPath: _light
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 7548684322398456783, guid: 50a6408f36e3a6c40b69e6f13afdcc45,
-        type: 3}
-      propertyPath: _layerMask.m_Bits
-      value: 512
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 50a6408f36e3a6c40b69e6f13afdcc45, type: 3}
---- !u!114 &2032370950346824818 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 7548684322398456783, guid: 50a6408f36e3a6c40b69e6f13afdcc45,
-    type: 3}
-  m_PrefabInstance: {fileID: 8427992991924230077}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 459600b07d94e9d4d9ce4fd6e26e0a2a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!4 &2032370950346824821 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 7548684322398456776, guid: 50a6408f36e3a6c40b69e6f13afdcc45,
-    type: 3}
-  m_PrefabInstance: {fileID: 8427992991924230077}
-  m_PrefabAsset: {fileID: 0}
+      m_Calls: []

--- a/Assets/Prefab/LightController.prefab
+++ b/Assets/Prefab/LightController.prefab
@@ -61,11 +61,13 @@ MonoBehaviour:
   _light: {fileID: 0}
   _layerMask:
     serializedVersion: 2
-    m_Bits: 1024
+    m_Bits: 512
   _targetSetting:
     color: {r: 0.19344072, g: 0.21399921, b: 0.5943396, a: 1}
     intensity: 1
   _transitionTime: 2
+  _minIntensity: 0.4
+  _maxIntensity: 1
   _curve:
     serializedVersion: 2
     m_Curve:

--- a/Assets/Prefab/Manager.meta
+++ b/Assets/Prefab/Manager.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8ef659a93d79b6b4ea886924722facb8
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefab/Manager/PollutionManager.prefab
+++ b/Assets/Prefab/Manager/PollutionManager.prefab
@@ -48,7 +48,7 @@ MonoBehaviour:
   particleSystems:
   - {fileID: 0}
   - {fileID: 0}
-  _updateTime: 0.1
+  _updateRate: 0.1
   OnPollutionEnd:
     m_PersistentCalls:
       m_Calls:
@@ -145,6 +145,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: LightController
+      objectReference: {fileID: 0}
+    - target: {fileID: 7548684322398456783, guid: 50a6408f36e3a6c40b69e6f13afdcc45,
+        type: 3}
+      propertyPath: _minIntensity
+      value: 0.25
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 50a6408f36e3a6c40b69e6f13afdcc45, type: 3}

--- a/Assets/Prefab/Manager/PollutionManager.prefab
+++ b/Assets/Prefab/Manager/PollutionManager.prefab
@@ -1,0 +1,168 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &8048384971452845092
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8048384971452845090}
+  - component: {fileID: 8048384971452845093}
+  m_Layer: 0
+  m_Name: PollutionManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8048384971452845090
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8048384971452845092}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.79340553, y: 1.5853729, z: 0.7061048}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2032064406334618298}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &8048384971452845093
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8048384971452845092}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5b45c06fda4fb794cb8930e654e65d4a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  particleSystems:
+  - {fileID: 0}
+  - {fileID: 0}
+  _updateTime: 0.1
+  OnPollutionEnd:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 2032064406334618301}
+        m_TargetAssemblyTypeName: LightController, Scripts
+        m_MethodName: EndLightEffect
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+  OnPollutionValue:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 2032064406334618301}
+        m_TargetAssemblyTypeName: LightController, Scripts
+        m_MethodName: Blend
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!1001 &8426524805222953330
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 8048384971452845090}
+    m_Modifications:
+    - target: {fileID: 7548684322398456776, guid: 50a6408f36e3a6c40b69e6f13afdcc45,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7548684322398456776, guid: 50a6408f36e3a6c40b69e6f13afdcc45,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7548684322398456776, guid: 50a6408f36e3a6c40b69e6f13afdcc45,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7548684322398456776, guid: 50a6408f36e3a6c40b69e6f13afdcc45,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7548684322398456776, guid: 50a6408f36e3a6c40b69e6f13afdcc45,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7548684322398456776, guid: 50a6408f36e3a6c40b69e6f13afdcc45,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7548684322398456776, guid: 50a6408f36e3a6c40b69e6f13afdcc45,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7548684322398456776, guid: 50a6408f36e3a6c40b69e6f13afdcc45,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7548684322398456776, guid: 50a6408f36e3a6c40b69e6f13afdcc45,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7548684322398456776, guid: 50a6408f36e3a6c40b69e6f13afdcc45,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7548684322398456776, guid: 50a6408f36e3a6c40b69e6f13afdcc45,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7548684322398456777, guid: 50a6408f36e3a6c40b69e6f13afdcc45,
+        type: 3}
+      propertyPath: m_Name
+      value: LightController
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 50a6408f36e3a6c40b69e6f13afdcc45, type: 3}
+--- !u!4 &2032064406334618298 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7548684322398456776, guid: 50a6408f36e3a6c40b69e6f13afdcc45,
+    type: 3}
+  m_PrefabInstance: {fileID: 8426524805222953330}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &2032064406334618301 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7548684322398456783, guid: 50a6408f36e3a6c40b69e6f13afdcc45,
+    type: 3}
+  m_PrefabInstance: {fileID: 8426524805222953330}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 459600b07d94e9d4d9ce4fd6e26e0a2a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Prefab/Manager/PollutionManager.prefab.meta
+++ b/Assets/Prefab/Manager/PollutionManager.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e7f786dd586038f4699039dad01c601b
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefab/XR Origin (XR Rig).prefab
+++ b/Assets/Prefab/XR Origin (XR Rig).prefab
@@ -2286,7 +2286,7 @@ MonoBehaviour:
   m_ConeCastAngle: 6
   m_RaycastMask:
     serializedVersion: 2
-    m_Bits: 4294967295
+    m_Bits: 503
   m_RaycastTriggerInteraction: 1
   m_RaycastSnapVolumeInteraction: 1
   m_HitClosestOnly: 0
@@ -2751,7 +2751,7 @@ MonoBehaviour:
   m_ConeCastAngle: 6
   m_RaycastMask:
     serializedVersion: 2
-    m_Bits: 4294967295
+    m_Bits: 503
   m_RaycastTriggerInteraction: 1
   m_RaycastSnapVolumeInteraction: 1
   m_HitClosestOnly: 0

--- a/Assets/Scenes/TEST - Editor Only/Jyama/JyamaDevScene.unity
+++ b/Assets/Scenes/TEST - Editor Only/Jyama/JyamaDevScene.unity
@@ -4259,11 +4259,6 @@ PrefabInstance:
       propertyPath: _light
       value: 
       objectReference: {fileID: 1411992518}
-    - target: {fileID: 2032064406334618301, guid: e7f786dd586038f4699039dad01c601b,
-        type: 3}
-      propertyPath: _minIntensity
-      value: 0.2
-      objectReference: {fileID: 0}
     - target: {fileID: 8048384971452845090, guid: e7f786dd586038f4699039dad01c601b,
         type: 3}
       propertyPath: m_RootOrder

--- a/Assets/Scenes/TEST - Editor Only/Jyama/JyamaDevScene.unity
+++ b/Assets/Scenes/TEST - Editor Only/Jyama/JyamaDevScene.unity
@@ -2598,7 +2598,7 @@ PrefabInstance:
     - target: {fileID: 1328957667535059133, guid: 86c7de76229deda4f9edcc925868b9e9,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 9.424652
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 1328957667535059133, guid: 86c7de76229deda4f9edcc925868b9e9,
         type: 3}
@@ -3355,6 +3355,18 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 510bedefa90708c4aa81aa06115c43b0, type: 3}
+--- !u!114 &1819874907 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1328957667535059132, guid: 86c7de76229deda4f9edcc925868b9e9,
+    type: 3}
+  m_PrefabInstance: {fileID: 1325340715}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7e4ac24bfd79c9e4a92de1e9b77b9e3b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &1854521621
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -3639,7 +3651,7 @@ PrefabInstance:
     - target: {fileID: 3859955815303043263, guid: ecc49fb8b645b4d4382a1784d8751ee8,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 9.584652
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 3859955815303043263, guid: ecc49fb8b645b4d4382a1784d8751ee8,
         type: 3}
@@ -3864,6 +3876,18 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1974866383}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &2135241186 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 3859955815303043262, guid: ecc49fb8b645b4d4382a1784d8751ee8,
+    type: 3}
+  m_PrefabInstance: {fileID: 1974866383}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7e4ac24bfd79c9e4a92de1e9b77b9e3b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &2696505796395784956
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -4213,3 +4237,122 @@ MonoBehaviour:
   Event:
     m_PersistentCalls:
       m_Calls: []
+--- !u!1001 &8048384971057797614
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2032064406334618298, guid: e7f786dd586038f4699039dad01c601b,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2032064406334618300, guid: e7f786dd586038f4699039dad01c601b,
+        type: 3}
+      propertyPath: m_Radius
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2032064406334618301, guid: e7f786dd586038f4699039dad01c601b,
+        type: 3}
+      propertyPath: _light
+      value: 
+      objectReference: {fileID: 1411992518}
+    - target: {fileID: 2032064406334618301, guid: e7f786dd586038f4699039dad01c601b,
+        type: 3}
+      propertyPath: _minIntensity
+      value: 0.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 8048384971452845090, guid: e7f786dd586038f4699039dad01c601b,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 8048384971452845090, guid: e7f786dd586038f4699039dad01c601b,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.79340553
+      objectReference: {fileID: 0}
+    - target: {fileID: 8048384971452845090, guid: e7f786dd586038f4699039dad01c601b,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.5853729
+      objectReference: {fileID: 0}
+    - target: {fileID: 8048384971452845090, guid: e7f786dd586038f4699039dad01c601b,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.7061048
+      objectReference: {fileID: 0}
+    - target: {fileID: 8048384971452845090, guid: e7f786dd586038f4699039dad01c601b,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8048384971452845090, guid: e7f786dd586038f4699039dad01c601b,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8048384971452845090, guid: e7f786dd586038f4699039dad01c601b,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8048384971452845090, guid: e7f786dd586038f4699039dad01c601b,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8048384971452845090, guid: e7f786dd586038f4699039dad01c601b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8048384971452845090, guid: e7f786dd586038f4699039dad01c601b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8048384971452845090, guid: e7f786dd586038f4699039dad01c601b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8048384971452845092, guid: e7f786dd586038f4699039dad01c601b,
+        type: 3}
+      propertyPath: m_Name
+      value: PollutionManager
+      objectReference: {fileID: 0}
+    - target: {fileID: 8048384971452845093, guid: e7f786dd586038f4699039dad01c601b,
+        type: 3}
+      propertyPath: particleSystems.Array.data[0]
+      value: 
+      objectReference: {fileID: 2135241186}
+    - target: {fileID: 8048384971452845093, guid: e7f786dd586038f4699039dad01c601b,
+        type: 3}
+      propertyPath: particleSystems.Array.data[1]
+      value: 
+      objectReference: {fileID: 1819874907}
+    m_RemovedComponents:
+    - {fileID: 2032064406334618300, guid: e7f786dd586038f4699039dad01c601b, type: 3}
+  m_SourcePrefab: {fileID: 100100000, guid: e7f786dd586038f4699039dad01c601b, type: 3}
+--- !u!1 &8048384971057797615 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2032064406334618299, guid: e7f786dd586038f4699039dad01c601b,
+    type: 3}
+  m_PrefabInstance: {fileID: 8048384971057797614}
+  m_PrefabAsset: {fileID: 0}
+--- !u!65 &8048384971057797616
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8048384971057797615}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 40, y: 5, z: 18}
+  m_Center: {x: 0, y: 0, z: 0}

--- a/Assets/Scripts/Pollution/LightController.cs
+++ b/Assets/Scripts/Pollution/LightController.cs
@@ -62,7 +62,6 @@ public class LightController : MonoBehaviour
         if (_inside || !_enableEffect) return;
         if (((1 << other.gameObject.layer) & _layerMask) == 0) return;
 
-        print("Enter");
         _inside = true;
         BlendToTarget();
     }

--- a/Assets/Scripts/Pollution/LightController.cs
+++ b/Assets/Scripts/Pollution/LightController.cs
@@ -27,17 +27,15 @@ public class LightController : MonoBehaviour
     [Space(5)]
     [SerializeField] private LightSetting _targetSetting = new(Color.white, 1f);
     [SerializeField, Min(0.1f)] private float _transitionTime = 1f;
-    [SerializeField, Range(0, 1)] private float _minIntensity = 0f, _maxIntensity = 1f;
+    [SerializeField, Range(0, 1), Tooltip("Inside Pollution light intensity")] private float _minIntensity = 0f, _maxIntensity = 1f;
 
-    [SerializeField] private AnimationCurve _curve = AnimationCurve.EaseInOut(0, 0, 1, 1);
+    [SerializeField, Tooltip("Transition blend curve")] private AnimationCurve _curve = AnimationCurve.EaseInOut(0, 0, 1, 1);
 
     private LightSetting _defaultSetting;
 
-    private float _time = 0f;
     private float _currentBlend = 0f, _targetBlend = 0f, _insideBlend = 1f;
     private Action<float> _curveAnimFn;
     private bool _inside = false, _enableEffect = true;
-    private Action _transisitionEnd;
 
     private void Awake()
     {
@@ -62,7 +60,6 @@ public class LightController : MonoBehaviour
         if (_inside || !_enableEffect) return;
         if (((1 << other.gameObject.layer) & _layerMask) == 0) return;
 
-        print("Enter");
         _inside = true;
         BlendToTarget();
     }
@@ -87,7 +84,6 @@ public class LightController : MonoBehaviour
     //Handles Animation curve for psuedo timeline
     private void PlayCurve(Action<float> cb)
     {
-        _time = 0;
         _curveAnimFn = cb;
         enabled = true;
     }
@@ -99,6 +95,7 @@ public class LightController : MonoBehaviour
 
         if (_currentBlend < _targetBlend)
         {
+            //increase to target
             return (float deltaTime) =>
             {
                 _currentBlend += deltaTime / _transitionTime;
@@ -114,6 +111,7 @@ public class LightController : MonoBehaviour
         }
         else
         {
+            //decrease to target
             return (float deltaTime) =>
             {
                 _currentBlend -= deltaTime / _transitionTime;
@@ -163,7 +161,9 @@ public class LightController : MonoBehaviour
 
     public void BlendToTarget()
     {
-        PlayCurve(MakeBlendFn(Mathf.Lerp(_minIntensity, _maxIntensity, _insideBlend)));
+        //Caps blended change by min / max
+        float intesity = Mathf.Lerp(_minIntensity, _maxIntensity, _insideBlend);
+        PlayCurve(MakeBlendFn(intesity));
     }
 
     public void Blend(float target)

--- a/Assets/Scripts/Pollution/ParticleTriggerManager.cs
+++ b/Assets/Scripts/Pollution/ParticleTriggerManager.cs
@@ -14,6 +14,7 @@ public class ParticleTriggerManager : MonoBehaviour
     [SerializeField, Tooltip("Time Threshold to Stop Particle"), Min(0)] private float _endTimeThreshold = 1;
     [SerializeField, Tooltip("Count Threshold to Stop Particle"), Min(0)] private int _particleCountThreshold = 0;
 
+    [SerializeField, Min(0.01f)] float _updateRate = 0.1f;
     [SerializeField] private string _tag = "DamageCollider";
 
     public UnityEvent OnParticleEnd;
@@ -21,17 +22,23 @@ public class ParticleTriggerManager : MonoBehaviour
     private readonly List<ParticleSystem.Particle> _enter = new List<ParticleSystem.Particle>();
     private float _time = 0;
 
+    public float MaxParticleCount { get; private set; }
+    public float ParticleCount { get { return _system.particleCount; } }
+
     private void Awake()
     {
         if (!_system)
             _system = GetComponent<ParticleSystem>();
 
+        //Grabs colliders by tag
         GameObject[] list = GameObject.FindGameObjectsWithTag(_tag);
 
         foreach (GameObject go in list)
         {
             _system.trigger.AddCollider(go.GetComponent<Collider>());
         }
+
+        MaxParticleCount = _system.startLifetime * _system.emission.rateOverTime.constant;
     }
 
     private void FixedUpdate()
@@ -70,7 +77,6 @@ public class ParticleTriggerManager : MonoBehaviour
 
     private void EndParticle()
     {
-        print("Particles is Ended");
         _system.Stop();
         enabled = false;
         OnParticleEnd.Invoke();

--- a/Assets/Scripts/Pollution/ParticleTriggerManager.cs
+++ b/Assets/Scripts/Pollution/ParticleTriggerManager.cs
@@ -14,7 +14,6 @@ public class ParticleTriggerManager : MonoBehaviour
     [SerializeField, Tooltip("Time Threshold to Stop Particle"), Min(0)] private float _endTimeThreshold = 1;
     [SerializeField, Tooltip("Count Threshold to Stop Particle"), Min(0)] private int _particleCountThreshold = 0;
 
-    [SerializeField, Min(0.01f)] float _updateRate = 0.1f;
     [SerializeField] private string _tag = "DamageCollider";
 
     public UnityEvent OnParticleEnd;

--- a/Assets/Scripts/Pollution/PollutionManager.cs
+++ b/Assets/Scripts/Pollution/PollutionManager.cs
@@ -1,0 +1,65 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+using UnityEngine.Events;
+
+public class PollutionManager : MonoBehaviour
+{
+    [SerializeField] List<ParticleTriggerManager> particleSystems = new List<ParticleTriggerManager>();
+    [SerializeField, Min(0.01f)] float _updateRate = 0.1f;
+    public UnityEvent OnPollutionEnd;
+    public UnityEvent<float> OnPollutionValue;
+
+    //Pollution Particle Counts
+    public float ParticleMaxCount { get; private set; }
+    public float ParticleCount { get { return GetParticleCount(); } }
+    public float PollutionPercent { get { return GetParticleCount() / ParticleMaxCount; } }
+
+    //Active Particle System counts.
+    public int ActiveCount { get; private set; }
+    public int ActiveTotalCount { get { return particleSystems.Count; } }
+
+    private void Start()
+    {
+        ParticleMaxCount = particleSystems.Aggregate<ParticleTriggerManager, float>(0, (acc, part) => acc + part.MaxParticleCount);
+        ActiveCount = ActiveTotalCount;
+
+        StartCoroutine(UpdatePollution());
+    }
+
+    private void OnEnable()
+    {
+        particleSystems.ForEach(part => part.OnParticleEnd.AddListener(HandleParticleEnd));
+    }
+
+    private void OnDisable()
+    {
+        particleSystems.ForEach(part => part.OnParticleEnd.RemoveListener(HandleParticleEnd));
+    }
+
+    private IEnumerator UpdatePollution()
+    {
+        while (ActiveCount > 0)
+        {
+            OnPollutionValue.Invoke(PollutionPercent);
+            yield return new WaitForSeconds(_updateRate);
+        }
+        yield return null;
+    }
+
+    private void HandleParticleEnd()
+    {
+        ActiveCount--;
+        if (ActiveCount <= 0)
+        {
+            OnPollutionEnd.Invoke();
+            enabled = false;
+        }
+    }
+
+    public float GetParticleCount()
+    {
+        return particleSystems.Aggregate<ParticleTriggerManager, float>(0, (acc, part) => acc + part.ParticleCount);
+    }
+}

--- a/Assets/Scripts/Pollution/PollutionManager.cs
+++ b/Assets/Scripts/Pollution/PollutionManager.cs
@@ -7,7 +7,9 @@ using UnityEngine.Events;
 public class PollutionManager : MonoBehaviour
 {
     [SerializeField] List<ParticleTriggerManager> particleSystems = new List<ParticleTriggerManager>();
-    [SerializeField, Min(0.01f)] float _updateRate = 0.1f;
+    [SerializeField, Min(0.01f), Tooltip("Rate (sec) OnPollutionValue is triggered")] float _updateRate = 0.1f;
+
+    [Space(5)]
     public UnityEvent OnPollutionEnd;
     public UnityEvent<float> OnPollutionValue;
 

--- a/Assets/Scripts/Pollution/PollutionManager.cs.meta
+++ b/Assets/Scripts/Pollution/PollutionManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5b45c06fda4fb794cb8930e654e65d4a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Added Pollution Manager & made prefab.
- Requires List of Particle Trigger Manager (Fog Prefabs)
- Hooks for Current Percentage (Coroutine tick) 
- Hook for End trigger (All fog completed).

## Light Controller Changes:
Moved Light controller to Pollution Manager.
- Added Min / Max intensity for inside fog trigger area.
- Updated to be target based / time based blending transition.
- Changed to Box collider (Should be adjusted / positioned to cover fog).
_Any Collider trigger would work_

## Misc:
Minor bug fix for Grab ray layer mask to ignore force field & player.

## TEST - Jyama dev map.
- Pollution lighting should change when getting close.
- Lighting becomes brighter as you clear pollution.
- Light should go to normal when all removed.